### PR TITLE
Android sdk升级API到v2版本

### DIFF
--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogSdkConfig.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogSdkConfig.java
@@ -38,11 +38,11 @@ public class LogSdkConfig {
   // Request queue has a limited size. If queue is full, new coming requests will be discarded
   public static int LOGSDK_QUEUE_SIZE = 100;
 
-  public static String HTTP_URL = "http://api.lambdacloud.com/log";
+  public static String HTTP_URL = "http://api.lambdacloud.com/log/v2";
 
   public static String LOG_TAG = "LambdacloudSDK";
 
-  public static int HTTP_STATUSCODE_SUCCESS = 204;
+  public static int HTTP_STATUSCODE_SUCCESS = 200;
 
   public static int HTTP_STATUSCODE_TOKENILLEGAL = 406;
 

--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogSender.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogSender.java
@@ -30,7 +30,7 @@ import android.util.Log;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
@@ -94,11 +94,11 @@ public class LogSender {
       se.setContentType("application/json");
 
       String serverUrl = LogSdkConfig.HTTP_URL;
-      HttpPost httpPost = new HttpPost(serverUrl);
-      httpPost.setHeader("Token", LogSdkConfig.LOGSDK_TOKEN);
-      httpPost.setHeader("Content-type", "application/json;charset=UTF-8");
-      httpPost.setEntity(se);
-      HttpResponse response = client.execute(httpPost);
+      HttpPut httpPut = new HttpPut(serverUrl);
+      httpPut.setHeader("Token", LogSdkConfig.LOGSDK_TOKEN);
+      httpPut.setHeader("Content-type", "application/json;charset=UTF-8");
+      httpPut.setEntity(se);
+      HttpResponse response = client.execute(httpPut);
 
       if (response == null) {
         LogUtil.debug(LogSdkConfig.LOG_TAG, "response from server side is null");

--- a/android/logsdk/src/test/java/com/lambdacloud/sdk/android/LogAgentTest.java
+++ b/android/logsdk/src/test/java/com/lambdacloud/sdk/android/LogAgentTest.java
@@ -67,19 +67,19 @@ public class LogAgentTest {
         // Config request rules
         WireMockConfiguration wireMockConfig = WireMockConfiguration.wireMockConfig();
         wireMockRule = new WireMockRule(wireMockConfig.port(8089));
-        wireMockRule.stubFor(post(urlMatching("/log"))
+        wireMockRule.stubFor(put(urlMatching("/log"))
                                  .withHeader("Content-Type", equalTo("application/json;charset=UTF-8"))
                                  .withHeader("Token", equalTo("C2D56BC4-D336-4248-9A9F-B0CC8F906671"))
                                  .willReturn(aResponse()
-                                                 .withStatus(204)
+                                                 .withStatus(200)
                                                  .withBody("log received")));
-        wireMockRule.stubFor(post(urlMatching("/log"))
+        wireMockRule.stubFor(put(urlMatching("/log"))
                                  .withHeader("Content-Type", equalTo("application/json;charset=UTF-8"))
                                  .withHeader("Token", equalTo("d029dfc9-c74f-4f31-b896-998f7d18fcfc"))
                                  .willReturn(aResponse()
                                                  .withStatus(406)
                                                  .withBody("token illegal")));
-        wireMockRule.stubFor(post(urlMatching("/log"))
+        wireMockRule.stubFor(put(urlMatching("/log"))
                                  .withHeader("Content-Type", equalTo("application/json;charset=UTF-8"))
                                  .withHeader("Token", equalTo("12345679-abcd-4f31-b896-998f7d18fcfc"))
                                  .willReturn(aResponse()
@@ -88,7 +88,7 @@ public class LogAgentTest {
         wireMockRule.addMockServiceRequestListener(new RequestListener() {
             @Override
             public void requestReceived(Request request, Response response) {
-                if (response.getStatus() == 204) {
+                if (response.getStatus() == 200) {
                     successReqs.add(LoggedRequest.createFrom(request));
                 } else if (response.getStatus() == 406) {
                     illegalReqs.add(LoggedRequest.createFrom(request));
@@ -117,8 +117,8 @@ public class LogAgentTest {
 
         Assert.assertEquals(successReqs.size(), 1);
         Assert.assertEquals(logSpout.queue.size(), 0);
-        wireMockRule.verify(1, postRequestedFor(urlEqualTo("/log")));
-        wireMockRule.verify(postRequestedFor(urlMatching("/log"))
+        wireMockRule.verify(1, putRequestedFor(urlEqualTo("/log")));
+        wireMockRule.verify(putRequestedFor(urlMatching("/log"))
                                 .withRequestBody(
                                     matching("\\{\"message\":\"test message from android sdk 0.0.1\"\\}")));
         successReqs.clear();
@@ -136,7 +136,7 @@ public class LogAgentTest {
 
         Assert.assertEquals(successReqs.size(), 1);
         Assert.assertEquals(logSpout.queue.size(), 0);
-        wireMockRule.verify(1, postRequestedFor(urlEqualTo("/log")));
+        wireMockRule.verify(1, putRequestedFor(urlEqualTo("/log")));
         successReqs.clear();
     }
 
@@ -152,8 +152,8 @@ public class LogAgentTest {
         Assert.assertEquals(illegalReqs.size(), 1);
         Assert.assertEquals(successReqs.size(), 0);
         Assert.assertEquals(logSpout.queue.size(), 0);
-        wireMockRule.verify(1, postRequestedFor(urlEqualTo("/log")));
-        wireMockRule.verify(postRequestedFor(urlMatching("/log"))
+        wireMockRule.verify(1, putRequestedFor(urlEqualTo("/log")));
+        wireMockRule.verify(putRequestedFor(urlMatching("/log"))
                                 .withRequestBody(
                                     matching("\\{\"message\":\"test message from android sdk 0.0.1\"\\}")));
 
@@ -184,8 +184,8 @@ public class LogAgentTest {
         Assert.assertEquals(successReqs.size(), 0);
         Assert.assertEquals(failedReqs.size(), 1);
         Assert.assertEquals(logSpout.queue.size(), 0);
-        wireMockRule.verify(1, postRequestedFor(urlEqualTo("/log")));
-        wireMockRule.verify(postRequestedFor(urlMatching("/log"))
+        wireMockRule.verify(1, putRequestedFor(urlEqualTo("/log")));
+        wireMockRule.verify(putRequestedFor(urlMatching("/log"))
                                 .withRequestBody(
                                     matching("\\{\"message\":\"test message from android sdk 0.0.1\"\\}")));
 
@@ -213,7 +213,7 @@ public class LogAgentTest {
 
         Assert.assertEquals(successReqs.size(), 1);
         Assert.assertEquals(logSpout.queue.size(), 0);
-        wireMockRule.verify(1, postRequestedFor(urlEqualTo("/log")));
+        wireMockRule.verify(1, putRequestedFor(urlEqualTo("/log")));
         successReqs.clear();
     }
 }

--- a/ios/src/xcode/logsdk/LogSdkConfig.h
+++ b/ios/src/xcode/logsdk/LogSdkConfig.h
@@ -31,7 +31,8 @@ extern NSString *const kHttpUrl;
 extern NSString *const kLogTag;
 extern NSInteger const kHttpTimeoutSec;
 extern NSInteger const kSpoutSleepTimeMS;
-extern NSInteger const kHttpStatusCode;
+extern NSInteger const kHttpStatusCodeSuccess;
+extern NSInteger const kHttpStatusCodeTokenIllegal;
 extern NSInteger  kQueueSize;
 
 @interface LogSdkConfig : NSObject

--- a/ios/src/xcode/logsdk/LogSdkConfig.m
+++ b/ios/src/xcode/logsdk/LogSdkConfig.m
@@ -31,11 +31,12 @@ static NSString *logSdkToken = nil;
 
 @implementation LogSdkConfig
 
-NSString *const kHttpUrl = @"http://api.lambdacloud.com/log";
+NSString *const kHttpUrl = @"http://api.lambdacloud.com/log/v2";
 NSString *const kLogTag = @"LambdacloudSDK";
 NSInteger const kHttpTimeoutSec = 60;
 NSInteger const kSpoutSleepTimeMS = 1000;
-NSInteger const kHttpStatusCode = 204;
+NSInteger const kHttpStatusCodeSuccess = 200;
+NSInteger const kHttpStatusCodeTokenIllegal = 406;
 NSInteger  kQueueSize = 100;
 
 + (NSString *)LogSdkToken

--- a/ios/src/xcode/logsdk/LogSpout.m
+++ b/ios/src/xcode/logsdk/LogSpout.m
@@ -65,23 +65,17 @@ static LogSpout *instance = nil;
 - (void)checkRequests
 {
     id req = [self firstReqInCache];
-
-    while (req) {
+    while([self getReqCountInCache] != 0){
         if ([req isKindOfClass:[LogRequest class]]) {
-            BOOL success = [LogSender sendRequest:req];
-
-            if (success) {
-                [self removeReqInCache:req];
-            } else {
+            if ( req == NULL ) {
                 break;
             }
+            [self removeReqInCache:req];
+            [LogSender sendRequest:req];
         } else {
-            // array element type should be LogRequest here
             NSLog(@"%@: element type of log request queue should only be LogRequest", kLogTag);
             [self removeReqInCache:req];
         }
-
-        req = [self firstReqInCache];
     }
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kSpoutSleepTimeMS * 0.001 * NSEC_PER_SEC)), timerQueue, ^{

--- a/ios/src/xcode/logsdkTests/LogSdkHttpTest.m
+++ b/ios/src/xcode/logsdkTests/LogSdkHttpTest.m
@@ -111,11 +111,13 @@
     }];
     
     // Send request
-    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogSdkConfig SetLogSdkToken:@"illegalToken"];
     NSArray     *tags = [NSArray arrayWithObjects:@"test", @"tag", @"cocoa", nil];
-    LogRequest  *req = [LogRequest createLogRequest:@"test testHttpRequestWithTags" tags:tags];
-    BOOL        fail = ![LogSender sendRequest:req];
-    XCTAssertTrue(fail);
+    LogRequest  *req = [LogRequest createLogRequest:@"test testHttpRequestWithIllegalToken" tags:tags];
+    BOOL        fail = [LogSender sendRequest:req];
+    XCTAssertFalse(fail);
+    fail = [LogSender sendRequest:req];
+    XCTAssertFalse(fail);
     
     // Close http stubs
     [OHHTTPStubs removeAllStubs];


### PR DESCRIPTION
https://github.com/lambdacloud/lanyun/issues/858
Android：
修改HTTP_URL为v2版本；
修改HttpPost方法为HttpPut，防止重复日志上传；
修改成功状态码为200。
并进行相应的单元测试。
Ios：
修改kHttpUrl为v2版本；
修改成功状态码为200，添加Token非法状态码406；
修改POST方法为PUT;
添加Token合法验证；
修正发送日志逻辑（先从发送队列中移除LogRequest类型日志，再将该条日志发送，避免发送日志出现异常，影响其他日志正常发送）。
并进行相应的单元测试。
