### PR TITLE
Android SDK 在应用打开时自动发送"设备信息"以及"应用列表"类型日志

### DIFF
--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/DeviceInfo.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/DeviceInfo.java
@@ -43,8 +43,16 @@ import java.util.List;
 public class DeviceInfo {
     private static Context appContext;
 
-    public static void init(Context context) {
-       appContext = context;
+    public static void init(Context context,String token) {
+        appContext = context;
+        try{
+            String imei = getImei();
+            LogAgent.setToken(token);
+            LogAgent.sendDeviceInfo(imei, null);
+            LogAgent.sendAppList(imei);
+        }catch (Exception e){
+            LogUtil.debug(LogSdkConfig.LOG_TAG,"Failed to send message while starting app.");
+        }
     }
 
     public static String getInternetConnectionStatus() {

--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogAgent.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogAgent.java
@@ -71,7 +71,8 @@ public class LogAgent {
         try {
             String basicPart = LogUtil.getBasicInfo("ldp_login", userID);
             String propPart = LogUtil.map2Str(properties);
-            String log = String.format("%s,ldp_serverID[%s]%s", basicPart, serverID, propPart);
+            String imei = DeviceInfo.getImei();
+            String log = String.format("%s,ldp_serverID[%s],ldp_imei[%s]%s", basicPart, serverID, imei, propPart);
             return sendLog(log);
         } catch (Exception e) {
             LogUtil.debug(LogSdkConfig.LOG_TAG, "sendLoginInfo failed with exception " + e.getMessage());

--- a/android/logsdk/src/test/java/com/lambdacloud/sdk/android/DeviceInfoTest.java
+++ b/android/logsdk/src/test/java/com/lambdacloud/sdk/android/DeviceInfoTest.java
@@ -48,13 +48,14 @@ public class DeviceInfoTest {
     @Before
     public void setUp() {
         Context context = Robolectric.application.getApplicationContext();
-        DeviceInfo.init(context);
+        DeviceInfo.init(context,"C2D56BC4-D336-4248-9A9F-B0CC8F906671");
+        LogSpout logSpout = LogSpout.getInstance();
+        logSpout.queue.clear();
     }
 
     @Test
     public void testGetConnectionStatusOnlyWWAN() {
         // Mock connectivity manager
-        Context context = Robolectric.getShadowApplication().getApplicationContext();
         ConnectivityManager connManager = (ConnectivityManager) Robolectric.application.getSystemService(Context.CONNECTIVITY_SERVICE);
         ShadowConnectivityManager sConnMng = Robolectric.shadowOf(connManager);
 
@@ -68,7 +69,6 @@ public class DeviceInfoTest {
                 ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_MOBILE_MMS, true, true);
         sConnMng.setNetworkInfo(ConnectivityManager.TYPE_MOBILE, mobile);
 
-        DeviceInfo.init(context);
         String connection = DeviceInfo.getInternetConnectionStatus();
         Assert.assertEquals(connection, DeviceInfoConstant.NETWORK_REACHABLE_VIA_WWAN);
     }
@@ -76,7 +76,6 @@ public class DeviceInfoTest {
     @Test
     public void testGetConnectionStatusBoth() {
         // Mock connectivity manager
-        Context context = Robolectric.getShadowApplication().getApplicationContext();
         ConnectivityManager connManager = (ConnectivityManager) Robolectric.application.getSystemService(Context.CONNECTIVITY_SERVICE);
         ShadowConnectivityManager sConnMng = Robolectric.shadowOf(connManager);
 
@@ -90,7 +89,6 @@ public class DeviceInfoTest {
                 ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_MOBILE_MMS, true, true);
         sConnMng.setNetworkInfo(ConnectivityManager.TYPE_MOBILE, mobile);
 
-        DeviceInfo.init(context);
         String connection = DeviceInfo.getInternetConnectionStatus();
         Assert.assertEquals(connection, DeviceInfoConstant.NETWORK_REACHABLE_VIA_WIFI);
     }
@@ -98,7 +96,6 @@ public class DeviceInfoTest {
     @Test
     public void testGetConnectionStatusConnecting() {
         // Mock connectivity manager
-        Context context = Robolectric.getShadowApplication().getApplicationContext();
         ConnectivityManager connManager = (ConnectivityManager) Robolectric.application.getSystemService(Context.CONNECTIVITY_SERVICE);
         ShadowConnectivityManager sConnMng = Robolectric.shadowOf(connManager);
 
@@ -112,7 +109,6 @@ public class DeviceInfoTest {
                 ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_MOBILE_MMS, true, false);
         sConnMng.setNetworkInfo(ConnectivityManager.TYPE_MOBILE, mobile);
 
-        DeviceInfo.init(context);
         String connection = DeviceInfo.getInternetConnectionStatus();
         Assert.assertEquals(connection, DeviceInfoConstant.NETWORK_NOT_REACHABLE);
     }


### PR DESCRIPTION
https://github.com/lambdacloud/lanyun/issues/900#issuecomment-159472457
添加功能:Android SDK 在应用打开时自动发送"设备信息"以及"应用列表"类型日志
因为添加上述功能后无法在应用初始化时得到用户ID，因此初始化时发送设备IMEI,之后用户登录后发送登录日志中添加IMEI字段，以此绑定用户ID和
IMEI。
添加测试:测试上述功能并通过