### PR TITLE
IOS SDK 升级版本为2.0版本

### DIFF
--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/DeviceInfo.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/DeviceInfo.java
@@ -76,12 +76,10 @@ public class DeviceInfo {
             cdtForLocation = new CountDownTimer(1000 * 60 * 2, 1000) {
                 @Override
                 public void onTick(long l) {
-                    LogUtil.debug(LogSdkConfig.LOG_TAG, "count down timer for location:" + String.valueOf(l));
                 }
 
                 @Override
                 public void onFinish() {
-                    LogUtil.debug(LogSdkConfig.LOG_TAG, "count down finished");
                     if (isLocationListener) {
                         locationManager.removeUpdates(locationListener);
                     }

--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogAgent.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogAgent.java
@@ -277,12 +277,13 @@ public class LogAgent {
         return false;
     }
 
-    public static boolean sendDeviceInfo(String userID, String[] method, Map<String, String> properties) {
+    public static boolean sendDeviceInfo(String userID, String methods, Map<String, String> properties) {
         try {
             String basicPart = LogUtil.getBasicInfo("ldp_device_info", userID);
             String propPart = LogUtil.map2Str(properties);
             StringBuilder log = new StringBuilder();
             log.append(basicPart);
+            String[] method = methods.split(",");
             for (int i = 0;i<method.length;i++) {
                 switch (method[i]) {
                     case LogSdkConfig.GET_OS_NAME:
@@ -313,6 +314,11 @@ public class LogAgent {
                         String operator = String.format("ldp_operator[%s]", DeviceInfo.getOperationInfo());
                         log.append("," + operator);
                         break;
+                    case LogSdkConfig.GET_BATTERY_POWER:
+                        DeviceInfo.getBatteryPower();
+                        break;
+                    case LogSdkConfig.GET_LOCATION:
+                        DeviceInfo.getLocation();
                 }
             }
             log.append(propPart);

--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogSdkConfig.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogSdkConfig.java
@@ -57,4 +57,6 @@ public class LogSdkConfig {
     public static final String GET_OS_VERSION = "getOsVersion";
     public static final String GET_SCREEN_DIMENSION = "getScreenDimension";
     public static final String GET_OPERATOR = "getOperatorInfo";
+    public static final String GET_BATTERY_POWER = "getBatteryPower";
+    public static final String GET_LOCATION = "getLocation";
 }

--- a/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogUtil.java
+++ b/android/logsdk/src/main/java/com/lambdacloud/sdk/android/LogUtil.java
@@ -43,15 +43,18 @@ public class LogUtil {
     }
 
     public static String getBasicInfo(String logtype, String userid) {
-        String basic = String.format("日志类型[%s],时间[%s],用户[%s],来源[客户端]", logtype, getTimestamp(), userid);
+        String basic = String.format("日志类型[%s],时间[%s],用户[%s],来源[客户端],设备平台[ANDROID]", logtype, getTimestamp(), userid);
         return basic;
     }
 
     // Timestamp in format of 2011-10-08T07:07:09+08:00
     public static String getTimestamp() {
         Date date = new Date();
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         String formattedDate = sdf.format(date);
+        if (!formattedDate.toLowerCase().endsWith("z")) {
+            formattedDate = formattedDate.substring(0, formattedDate.length() - 2) + ":00";
+        }
         return formattedDate;
     }
 

--- a/android/logsdk/src/test/java/com/lambdacloud/sdk/android/LogAgentTest.java
+++ b/android/logsdk/src/test/java/com/lambdacloud/sdk/android/LogAgentTest.java
@@ -222,10 +222,7 @@ public class LogAgentTest {
     @Test
     public void testSendDeviceInfoWithSpecificMethods() {
         LogAgent.setToken("C2D56BC4-D336-4248-9A9F-B0CC8F906671");
-        String[] methods = new String[]{
-                "getDeviceName",
-                "getOsName"
-        };
+        String methods = "getImei,getOperatorInfo,";
         LogAgent.sendDeviceInfo("userId",methods,null);
 
         LogSpout logSpout = LogSpout.getInstance();

--- a/ios/src/xcode/logsdk/LogAgent.h
+++ b/ios/src/xcode/logsdk/LogAgent.h
@@ -30,7 +30,7 @@
 @interface LogAgent : NSObject
 
 + (void)setToken:(NSString *)token;
-+ (void)SetMaxQueueSize:(NSInteger)maxQueueSize;
++ (void)setMaxQueueSize:(NSInteger)maxQueueSize;
 + (BOOL)addLog:(NSString *)message;
 + (BOOL)addLog:(NSString *)message tags:(NSArray *)tags;
 + (void)setDebugMode:(BOOL)debug;

--- a/ios/src/xcode/logsdk/LogAgent.h
+++ b/ios/src/xcode/logsdk/LogAgent.h
@@ -34,5 +34,37 @@
 + (BOOL)addLog:(NSString *)message;
 + (BOOL)addLog:(NSString *)message tags:(NSArray *)tags;
 + (void)setDebugMode:(BOOL)debug;
-+ (void)debug:(NSString *)tag message:(NSString *)message;
+//设备信息日志发送接口
++ (BOOL)sendDeviceInfo:(NSString *)userId properties:(NSMutableDictionary *)properties;
++ (BOOL)sendDeviceInfo:(NSString *)userId methods:(NSArray *)methods properties:(NSMutableDictionary *)properties;
+//渠道信息日志发送接口
++ (BOOL)sendChannelInfo:(NSString *)userId channelId:(NSString *)channelId properties:(NSMutableDictionary *)properties;
+//登录登出日志发送接口
++ (BOOL)sendLoginInfo:(NSString *)userId serverId:(NSString *)serverId properties:(NSMutableDictionary *)properties;
++ (BOOL)sendLogoutInfo:(NSString *)userId properties:(NSMutableDictionary *)properties;
+//用户标签日志发送接口
++ (BOOL)sendUserTag:(NSString *)userId tag:(NSString *)tag subTag:(NSString *)subTag;
+//关卡日志发送接口
++ (BOOL)sendLevelBeginInfo:(NSString *)userId levelName:(NSString *)levelName properties:(NSMutableDictionary *)properties;
++ (BOOL)sendLevelComleteInfo:(NSString *)userId levelName:(NSString *)levelName properties:(NSMutableDictionary *)properties;
++ (BOOL)sendLevelFailInfo:(NSString *)userId levelName:(NSString *)levelName properties:(NSMutableDictionary *)properties;
+//任务日志发送接口
++ (BOOL)sendTaskBeginInfo:(NSString *)userId taskName:(NSString *)taskName properties:(NSMutableDictionary *)properties;
++ (BOOL)sendTaskComleteInfo:(NSString *)userId taskName:(NSString *)taskName properties:(NSMutableDictionary *)properties;
++ (BOOL)sendTaskFailInfo:(NSString *)userId taskName:(NSString *)taskName properties:(NSMutableDictionary *)properties;
+//物品信息日志发送接口
++ (BOOL)sendGetItemInfo:(NSString *)userId itemName:(NSString *)itemName properties:(NSMutableDictionary *)properties;
++ (BOOL)sendBuyItemInfo:(NSString *)userId itemName:(NSString *)itemName properties:(NSMutableDictionary *)properties;
++ (BOOL)sendConsumeItemInfo:(NSString *)userId itemName:(NSString *)itemName properties:(NSMutableDictionary *)properties;
+//金币信息日志发送接口
++ (BOOL)sendGainCoinInfo:(NSString *)userId coinType:(NSString *)coinType gain:(long)gain total:(long)total reason:(NSString *)reason properties:(NSMutableDictionary *)properties;
++ (BOOL)sendConsumeCoinInfo:(NSString *)userId coinType:(NSString *)coinType use:(long)use total:(long)total reason:(NSString *)reason properties:(NSMutableDictionary *)properties;
+//支付信息日志发送接口
++ (BOOL)sendCurrencyPaymentInfo:(NSString *)userId orderId:(NSString *)orderId iapId:(NSString *)iapId amount:(NSString *)amount currencyType:(NSString *)currencyType paymentType:(NSString *)paymentType properties:(NSMutableDictionary *)properties;
+//自定义日志发送接口
++ (BOOL)sendCustomizedInfo:(NSString *)userId logType:(NSString *)logType properties:(NSMutableDictionary *)properties;
+//漏斗日志发送接口
++ (BOOL)sendCustomizedFunnel:(NSString *)
+userId funnelType:(NSString *)funnelType stepName:(NSString *)stepName stepStatus:(NSString *)stepStatus description:(NSString *)description properties:(NSMutableDictionary *)properties;
+
 @end

--- a/ios/src/xcode/logsdk/LogAgent.mm
+++ b/ios/src/xcode/logsdk/LogAgent.mm
@@ -38,7 +38,7 @@
     [LogSdkConfig SetLogSdkToken:token];
 }
 
-+ (void)SetMaxQueueSize:(NSInteger)maxQueueSize{
++ (void)setMaxQueueSize:(NSInteger)maxQueueSize{
     if(maxQueueSize>0)
     kQueueSize =maxQueueSize;
 }

--- a/ios/src/xcode/logsdk/LogAgent.mm
+++ b/ios/src/xcode/logsdk/LogAgent.mm
@@ -81,6 +81,9 @@
     NSString *propPart = [LogUtil dic2str:properties];
     NSMutableString *log = [[NSMutableString alloc]init];
     [log appendString:basicPart];
+    if (methods == NULL || [methods count] == 0) {
+        return false;
+    }
     for (int i=0;i<[methods count];i++) {
         if ([[methods objectAtIndex:i] isEqualToString:kGetDeviceName]==YES) {
             NSString *deviceName = [[NSString alloc]initWithFormat:@",ldp_device_name[%@]",[DeviceInfo getDeviceName]];
@@ -141,7 +144,6 @@
 
     [LogUtil debug:kLogTag message:log];
     return [LogAgent addLog:log];
-
     
 }
 

--- a/ios/src/xcode/logsdk/LogAgent.mm
+++ b/ios/src/xcode/logsdk/LogAgent.mm
@@ -50,14 +50,12 @@
 
 + (BOOL)addLog:(NSString *)message
 {
-    NSString *str = [[NSString alloc]initWithFormat:@"%@%@",message,@",设备平台[IOS]"];
-    return [[LogSpout sharedInstance] addRequest:str];
+    return [[LogSpout sharedInstance] addRequest:message];
 }
 
 + (BOOL)addLog:(NSString *)message tags:(NSArray *)tags
 {
-    NSString *str = [[NSString alloc]initWithFormat:@"%@%@",message,@",设备平台[IOS]"];
-    return [[LogSpout sharedInstance] addRequest:str tags:tags];
+    return [[LogSpout sharedInstance] addRequest:message tags:tags];
 }
 
 + (BOOL)sendDeviceInfo:(NSString *)userId properties:(NSMutableDictionary *)properties

--- a/ios/src/xcode/logsdk/LogAgent.mm
+++ b/ios/src/xcode/logsdk/LogAgent.mm
@@ -28,6 +28,8 @@
 #import "LogAgent.h"
 #import "LogSdkConfig.h"
 #import "LogSpout.h"
+#import "DeviceInfo.h"
+#import "LogUtil.h"
 
 @implementation LogAgent
 
@@ -39,6 +41,11 @@
 + (void)SetMaxQueueSize:(NSInteger)maxQueueSize{
     if(maxQueueSize>0)
     kQueueSize =maxQueueSize;
+}
+
++ (void)setDebugMode:(BOOL)debug
+{
+    kDebug = debug;
 }
 
 + (BOOL)addLog:(NSString *)message
@@ -53,16 +60,244 @@
     return [[LogSpout sharedInstance] addRequest:str tags:tags];
 }
 
-+ (void)setDebugMode:(BOOL)debug
++ (BOOL)sendDeviceInfo:(NSString *)userId properties:(NSMutableDictionary *)properties
 {
-    kDebug = debug;
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_device_info" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *deviceName = [DeviceInfo getDeviceName];
+    NSString *internetConnectionStatus = [DeviceInfo getInternetConnectionStatus];
+    NSString *operatorInfo = [DeviceInfo getOperationInfo];
+    NSString *systemOs = [DeviceInfo getSystemOS];
+
+    NSString *log = [[NSString alloc]initWithFormat:@"%@,ldp_device_name[%@],ldp_connection_status[%@],ldp_os_version[%@],ldp_operator[%@]%@",basicPart, deviceName, internetConnectionStatus, systemOs, operatorInfo, propPart];
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
 }
 
-+ (void)debug:(NSString *)tag message:(NSString *)message
++ (BOOL)sendDeviceInfo:(NSString *)userId methods:(NSArray *)methods properties:(NSMutableDictionary *)properties
 {
-    if([LogSdkConfig kDebug]){
-        NSLog(@"%@:%@",tag,message);
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_device_info" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    NSMutableString *log = [[NSMutableString alloc]init];
+    [log appendString:basicPart];
+    for (int i=0;i<[methods count];i++) {
+        if ([[methods objectAtIndex:i] isEqualToString:kGetDeviceName]==YES) {
+            NSString *deviceName = [[NSString alloc]initWithFormat:@",ldp_device_name[%@]",[DeviceInfo getDeviceName]];
+            [log appendString:deviceName];
+        } else if ([methods[i] isEqualToString:kGetInternetConnectionStatus]==YES){
+            NSString *internetConnectionStatus = [[NSString alloc]initWithFormat:@",ldp_connection_status[%@]",[DeviceInfo getInternetConnectionStatus]];
+            [log appendString:internetConnectionStatus];
+        } else if ([methods[i] isEqualToString:kGetOperationInfo]==YES){
+            NSString *operatorInfo = [[NSString alloc]initWithFormat:@",ldp_operator[%@]",[DeviceInfo getOperationInfo]];
+            [log appendString:operatorInfo];
+        } else if ([methods[i] isEqualToString:kGetSystemOs]==YES){
+            NSString *systemOs = [[NSString alloc]initWithFormat:@",ldp_os_version[%@]",[DeviceInfo getSystemOS]];
+            [log appendString:systemOs];
+        }
     }
+    [log appendString:propPart];
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendChannelInfo:(NSString *)userId channelId:(NSString *)channelId properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_channel_info" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_channelID[%@]%@", basicPart, channelId, propPart];
+
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendLoginInfo:(NSString *)userId serverId:(NSString *)serverId properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_login_info" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_serverID[%@]%@",basicPart, serverId, propPart];
+
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendLogoutInfo:(NSString *)userId properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_logout_info" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+  
+    NSString *log = [NSString stringWithFormat:@"%@%@",basicPart, propPart];
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+
+}
+
++ (BOOL)sendUserTag:(NSString *)userId tag:(NSString *)tag subTag:(NSString *)subTag
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_user_tag" userId:userId];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_user_tag[%@],ldp_user_sub_tag[%@]",basicPart,tag,subTag];
+
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+
+    
+}
+
++ (BOOL)sendLevelBeginInfo:(NSString *)userId levelName:(NSString *)levelName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_level_begin" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_level_name[%@],ldp_status[begin]%@",basicPart, levelName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendLevelComleteInfo:(NSString *)userId levelName:(NSString *)levelName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_level_complete" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_level_name[%@],ldp_status[complete]%@",basicPart, levelName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendLevelFailInfo:(NSString *)userId levelName:(NSString *)levelName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_level_fail" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_level_name[%@],ldp_status[fail]%@",basicPart, levelName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendTaskBeginInfo:(NSString *)userId taskName:(NSString *)taskName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_task_begin" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_task_name[%@],ldp_status[begin]%@",basicPart, taskName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendTaskComleteInfo:(NSString *)userId taskName:(NSString *)taskName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_task_complete" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_task_name[%@],ldp_status[complete]%@",basicPart, taskName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendTaskFailInfo:(NSString *)userId taskName:(NSString *)taskName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_task_fail" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_task_name[%@],ldp_status[fail]%@",basicPart, taskName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendGetItemInfo:(NSString *)userId itemName:(NSString *)itemName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_item_get" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_item_name[%@]%@",basicPart, itemName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendBuyItemInfo:(NSString *)userId itemName:(NSString *)itemName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_item_buy" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_item_name[%@]%@",basicPart, itemName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendConsumeItemInfo:(NSString *)userId itemName:(NSString *)itemName properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_item_consume" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_item_name[%@]%@",basicPart, itemName, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendGainCoinInfo:(NSString *)userId coinType:(NSString *)coinType gain:(long)gain total:(long)total reason:(NSString *)reason properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_coin_gain" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_coin_type[%@],gain[%ld],total[%ld],reason[%@]%@",basicPart, coinType, gain, total, reason, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendConsumeCoinInfo:(NSString *)userId coinType:(NSString *)coinType use:(long)use total:(long)total reason:(NSString *)reason properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_coin_consume" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_coin_type[%@],use[%ld],total[%ld],reason[%@]%@",basicPart, coinType, use, total, reason, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendCurrencyPaymentInfo:(NSString *)userId orderId:(NSString *)orderId iapId:(NSString *)iapId amount:(NSString *)amount currencyType:(NSString *)currencyType paymentType:(NSString *)paymentType properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:@"ldp_currency_payment" userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+   
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_order_id[%@],ldp_iap_id[%@],ldp_amount[%@],ldp_currency_type[%@],ldp_payment_type[%@]%@",basicPart, orderId, iapId, amount, currencyType, paymentType, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendCustomizedInfo:(NSString *)userId logType:(NSString *)logType properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:logType userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@%@",basicPart, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+}
+
++ (BOOL)sendCustomizedFunnel:(NSString *)userId funnelType:(NSString *)funnelType stepName:(NSString *)stepName stepStatus:(NSString *)stepStatus description:(NSString *)description properties:(NSMutableDictionary *)properties
+{
+    NSString *basicPart = [LogUtil getBasicInfo:funnelType userId:userId];
+    NSString *propPart = [LogUtil dic2str:properties];
+    
+    NSString *log = [NSString stringWithFormat:@"%@,ldp_step_name[%@],ldp_step_status[%@],ldp_desc[%@]%@",basicPart, stepName, stepStatus, description, propPart];
+    
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+
 }
 
 @end

--- a/ios/src/xcode/logsdk/LogRequest.mm
+++ b/ios/src/xcode/logsdk/LogRequest.mm
@@ -28,6 +28,7 @@
 #import "LogRequest.h"
 #import "LogSdkConfig.h"
 #import "LogAgent.h"
+#import "LogUtil.h"
 
 @implementation LogRequest
 
@@ -68,7 +69,7 @@
     if (!jsonData) {
         NSString *message = [[NSString alloc]initWithFormat:
                              @"Got an exception while generating json data for log %@", error];
-        [LogAgent debug:kLogTag message:message];
+        [LogUtil debug:kLogTag message:message];
     }
 
     return jsonData;

--- a/ios/src/xcode/logsdk/LogSdkConfig.h
+++ b/ios/src/xcode/logsdk/LogSdkConfig.h
@@ -35,6 +35,11 @@ extern NSInteger const kHttpStatusCodeSuccess;
 extern NSInteger const kHttpStatusCodeTokenIllegal;
 extern BOOL kDebug;
 extern NSInteger  kQueueSize;
+//method name
+extern NSString *const kGetInternetConnectionStatus;
+extern NSString *const kGetDeviceName;
+extern NSString *const kGetOperationInfo;
+extern NSString *const kGetSystemOs;
 
 @interface LogSdkConfig : NSObject
 

--- a/ios/src/xcode/logsdk/LogSender.mm
+++ b/ios/src/xcode/logsdk/LogSender.mm
@@ -28,6 +28,7 @@
 #import "LogSender.h"
 #import "LogSdkConfig.h"
 #import "LogAgent.h"
+#import "LogUtil.h"
 
 static NSString *illegalToken = nil;
 
@@ -39,19 +40,19 @@ static NSString *illegalToken = nil;
     NSData      *json = [request toJsonStr];
     NSString *content = [[NSString alloc] initWithData:json  encoding:NSUTF8StringEncoding];
     
-    [LogAgent debug:kLogTag message:content];
+    [LogUtil debug:kLogTag message:content];
     
     if (![LogSdkConfig LogSdkToken]){
-        [LogAgent debug:kLogTag message:@"Token shouldn't be empty."];
+        [LogUtil debug:kLogTag message:@"Token shouldn't be empty."];
         return false;
     } else if (illegalToken != NULL&&[illegalToken compare:[LogSdkConfig LogSdkToken] options:NSCaseInsensitiveSearch] == NSOrderedSame){
-        [LogAgent debug:kLogTag message:@"Token is illegal, so we won't send this log any more."];
+        [LogUtil debug:kLogTag message:@"Token is illegal, so we won't send this log any more."];
         
         return false;
     }
 
     if (!json) {
-        [LogAgent debug:kLogTag message:@"json data is null, skip this log."];
+        [LogUtil debug:kLogTag message:@"json data is null, skip this log."];
         
         return true;
     }
@@ -67,22 +68,22 @@ static NSString *illegalToken = nil;
     [NSURLConnection sendSynchronousRequest:http returningResponse:&response error:&error];
 
     if (!response) {
-        [LogAgent debug:kLogTag message:@"response from server side is null."];
+        [LogUtil debug:kLogTag message:@"response from server side is null."];
         return false;
     }
     
     if ([response statusCode] != kHttpStatusCodeSuccess) {
         NSString *message = [[NSString alloc]initWithFormat:@"value of response status code is not expected. detail is:%ld", (long)[response statusCode]];
-        [LogAgent debug:kLogTag message:message];
+        [LogUtil debug:kLogTag message:message];
         if([response statusCode] == kHttpStatusCodeTokenIllegal){
             NSString *message = [[NSString alloc]initWithFormat:@"The response code %ld means that the token is illegal, so we won't send this log any more.",(long)[response statusCode]];
-            [LogAgent debug:kLogTag message:message];
+            [LogUtil debug:kLogTag message:message];
             illegalToken = [LogSdkConfig LogSdkToken];
                   }
         return false;
     }
 
-    [LogAgent debug:kLogTag message:@"sent one log message to lambda cloud successfully"];
+    [LogUtil debug:kLogTag message:@"sent one log message to lambda cloud successfully"];
     return true;
 }
 

--- a/ios/src/xcode/logsdk/LogSpout.mm
+++ b/ios/src/xcode/logsdk/LogSpout.mm
@@ -30,6 +30,7 @@
 #import "LogSender.h"
 #import "LogSdkConfig.h"
 #import "LogAgent.h"
+#import "LogUtil.h"
 
 @implementation LogSpout
 
@@ -74,7 +75,7 @@ static LogSpout *instance = nil;
             }
         
         } else {
-            [LogAgent debug:kLogTag message:@"element type of log request queue should only be LogRequest"];
+            [LogUtil debug:kLogTag message:@"element type of log request queue should only be LogRequest"];
             [self removeReqInCache:req];
         }
     }
@@ -125,7 +126,7 @@ static LogSpout *instance = nil;
 
     if (count >= kQueueSize) {
         NSString *message = [[NSString alloc]initWithFormat:@"Log is discard since queue size is %lu",(unsigned long)[cache count]];
-        [LogAgent debug:kLogTag message:message];
+        [LogUtil debug:kLogTag message:message];
         return false;
     }
 

--- a/ios/src/xcode/logsdk/LogUtil.h
+++ b/ios/src/xcode/logsdk/LogUtil.h
@@ -25,44 +25,15 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "LogSdkConfig.h"
+#import <Foundation/Foundation.h>
 
-static NSString *logSdkToken = nil;
 
-@implementation LogSdkConfig
 
-NSString *const kHttpUrl = @"http://api.lambdacloud.com/log/v2";
-NSString *const kLogTag = @"LambdacloudSDK";
-NSInteger const kHttpTimeoutSec = 60;
-NSInteger const kSpoutSleepTimeMS = 1000;
-NSInteger const kHttpStatusCodeSuccess = 200;
-NSInteger const kHttpStatusCodeTokenIllegal = 406;
-BOOL kDebug = false;
-NSInteger  kQueueSize = 100;
-//method name
-NSString *const kGetInternetConnectionStatus = @"getInternetConnectionStatus";
-NSString *const kGetDeviceName = @"getDeviceName";
-NSString *const kGetOperationInfo = @"getOperationInfo";
-NSString *const kGetSystemOs = @"getSystemOs";
+@interface LogUtil : NSObject
 
-+ (NSString *)LogSdkToken
-{
-    @synchronized(self) {
-        return logSdkToken;
-    }
-}
-+ (NSInteger)kQueueSize{
-    return kQueueSize;
-}
-+ (BOOL)kDebug{
-    return kDebug;
-}
-
-+ (void)SetLogSdkToken:(NSString *)token
-{
-    @synchronized(self) {
-        logSdkToken = token;
-    }
-}
++ (void)debug:(NSString *)tag message:(NSString *)message;
++ (NSString *)getBasicInfo:(NSString *)logType userId:(NSString *)userId;
++ (NSString *)getTimeStamp;
++ (NSString *)dic2str:(NSMutableDictionary *)properties;
 
 @end

--- a/ios/src/xcode/logsdk/LogUtil.mm
+++ b/ios/src/xcode/logsdk/LogUtil.mm
@@ -25,44 +25,52 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#import <CoreTelephony/CTCarrier.h>
+#import <sys/utsname.h>
+#import "DeviceInfo.h"
+#import "Reachability.h"
 #import "LogSdkConfig.h"
+#import "LogUtil.h"
 
-static NSString *logSdkToken = nil;
+@implementation LogUtil : NSObject 
 
-@implementation LogSdkConfig
-
-NSString *const kHttpUrl = @"http://api.lambdacloud.com/log/v2";
-NSString *const kLogTag = @"LambdacloudSDK";
-NSInteger const kHttpTimeoutSec = 60;
-NSInteger const kSpoutSleepTimeMS = 1000;
-NSInteger const kHttpStatusCodeSuccess = 200;
-NSInteger const kHttpStatusCodeTokenIllegal = 406;
-BOOL kDebug = false;
-NSInteger  kQueueSize = 100;
-//method name
-NSString *const kGetInternetConnectionStatus = @"getInternetConnectionStatus";
-NSString *const kGetDeviceName = @"getDeviceName";
-NSString *const kGetOperationInfo = @"getOperationInfo";
-NSString *const kGetSystemOs = @"getSystemOs";
-
-+ (NSString *)LogSdkToken
++ (void)debug:(NSString *)tag message:(NSString *)message
 {
-    @synchronized(self) {
-        return logSdkToken;
+    if([LogSdkConfig kDebug]){
+        NSLog(@"%@:%@",tag,message);
     }
 }
-+ (NSInteger)kQueueSize{
-    return kQueueSize;
-}
-+ (BOOL)kDebug{
-    return kDebug;
+
++ (NSString *)getBasicInfo:(NSString *)logType userId:(NSString *)userId
+{
+    NSString *basicInfo = [[NSString alloc]initWithFormat:@"日志类型[%@],时间[%@],用户[%@],来源[客户端],设备平台[IOS]",logType,[LogUtil getTimeStamp],userId];
+    return basicInfo;
 }
 
-+ (void)SetLogSdkToken:(NSString *)token
++ (NSString *)getTimeStamp
 {
-    @synchronized(self) {
-        logSdkToken = token;
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"];
+    NSString *currentDateStr = [dateFormatter stringFromDate:[NSDate date]];
+    //输出格式为：2015-12-21T17:26:24.267+08:00
+    return currentDateStr;
+}
+
++ (NSString *)dic2str:(NSMutableDictionary *)properties
+{
+    if (properties == NULL || [properties count] == 0) {
+        return @"";
     }
+    NSMutableString *str = [[NSMutableString alloc]init];
+    for (NSString *key in properties) {
+        [str appendString:@","];
+        [str appendString:key];
+        [str appendString:@"["];
+        [str appendString:[properties objectForKey:key]];
+        [str appendString:@"]"];
+    }
+    return str;
 }
 
 @end

--- a/ios/src/xcode/logsdk/Reachability.mm
+++ b/ios/src/xcode/logsdk/Reachability.mm
@@ -55,6 +55,7 @@
 #import "Reachability.h"
 #import "LogAgent.h"
 #import "LogSdkConfig.h"
+#import "LogUtil.h"
 
 
 NSString *kReachabilityChangedNotification = @"kNetworkReachabilityChangedNotification";
@@ -80,7 +81,7 @@ static void PrintReachabilityFlags(SCNetworkReachabilityFlags flags, const char*
                         (flags & kSCNetworkReachabilityFlagsIsLocalAddress)       ? 'l' : '-',
                         (flags & kSCNetworkReachabilityFlagsIsDirect)             ? 'd' : '-',
                         comment];
-    [LogAgent debug:kLogTag message:message];
+    [LogUtil debug:kLogTag message:message];
 #endif
 }
 

--- a/ios/src/xcode/logsdkTests/LogAgentTest.m
+++ b/ios/src/xcode/logsdkTests/LogAgentTest.m
@@ -78,6 +78,12 @@
     BOOL  s2 = [LogAgent sendDeviceInfo:userId methods:methods properties:NULL];
     XCTAssertTrue(s2);
     
+    //发送空方法名
+    XCTAssertFalse([LogAgent sendDeviceInfo:userId methods:NULL properties:NULL]);
+    
+    //发送大小为0的methods
+    NSArray *method = [[NSArray alloc]init];
+    XCTAssertFalse([LogAgent sendDeviceInfo:userId methods:method properties:NULL]);
     // Close http stubs
     [OHHTTPStubs removeAllStubs];
 }
@@ -157,7 +163,7 @@
     // Send request
     [LogSdkConfig SetLogSdkToken:@"testtoken"];
     [LogAgent setDebugMode:true];
-
+    
     //测试数据
     NSString *userId = @"西游记";
     NSString *beginLevelName = @"大闹天宫";
@@ -172,6 +178,33 @@
     
     //失败关卡信息日志发送接口测试
     XCTAssertTrue([LogAgent sendLevelFailInfo:userId levelName:failLevelName properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//用户标签信息日志发送接口测试
+- (void)testSendUserTagInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+
+    //测试数据
+    NSString *userId = @"西游记";
+    NSString *tag = @"付费玩家";
+    NSString *subTag = @"小额付费玩家";
+    //用户标签信息发送接口测试
+    XCTAssertTrue([LogAgent sendUserTag:userId tag:tag subTag:subTag]);
     
     // Close http stubs
     [OHHTTPStubs removeAllStubs];

--- a/ios/src/xcode/logsdkTests/LogAgentTest.m
+++ b/ios/src/xcode/logsdkTests/LogAgentTest.m
@@ -1,0 +1,371 @@
+/**
+ *   Copyright (c) 2015, LambdaCloud
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "OHHTTPStubs.h"
+#import "LogSdkConfig.h"
+#import "LogRequest.h"
+#import "LogSender.h"
+#import "LogSpout.h"
+#import "LogAgent.h"
+
+@interface LogAgentTest : XCTestCase
+
+@end
+
+@implementation LogAgentTest
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+//设备信息日志发送接口测试
+- (void)testSendDeviceInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"testId";
+    NSArray *methods = [[NSArray alloc]initWithObjects:@"getDeviceName",@"getSystemOs",@"getOperationInfo",nil];
+    
+    //发送所有设备信息日志测试
+    BOOL  s1 = [LogAgent sendDeviceInfo:userId properties:NULL];
+    XCTAssertTrue(s1);
+    
+    //发送指定设备信息日志测试
+    BOOL  s2 = [LogAgent sendDeviceInfo:userId methods:methods properties:NULL];
+    XCTAssertTrue(s2);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//渠道信息日志发送接口测试
+- (void)testSendChannelInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    
+    //测试数据
+    NSString *userId = @"testUserId";
+    NSString *channelId = @"testChannelId";
+    [LogAgent setDebugMode:true];
+
+    //渠道信息日志发送接口测试
+    BOOL  success = [LogAgent sendChannelInfo:userId channelId:channelId properties:NULL];
+    XCTAssertTrue(success);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//登录登出信息日志发送接口测试
+- (void)testSendLoginAndLogoutInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+
+    //测试数据
+    NSString *userId = @"testUserId";
+    NSString *serverId = @"testServerId";
+    
+    //登录信息日志发送接口测试
+    BOOL  s1 = [LogAgent sendLoginInfo:userId serverId:serverId properties:NULL];
+    XCTAssertTrue(s1);
+    
+    //登出信息日志发送接口测试
+    BOOL  success = [LogAgent sendLogoutInfo:userId  properties:NULL];
+    XCTAssertTrue(success);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//关卡信息日志发送接口测试
+- (void)testSendLevelInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+
+    //测试数据
+    NSString *userId = @"西游记";
+    NSString *beginLevelName = @"大闹天宫";
+    NSString *completeLevelName = @"三打白骨精";
+    NSString *failLevelName = @"女儿国";
+    
+    //开始关卡信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendLevelBeginInfo:userId levelName:beginLevelName properties:NULL]);
+    
+    //完成关卡信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendLevelComleteInfo:userId levelName:completeLevelName properties:NULL]);
+    
+    //失败关卡信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendLevelFailInfo:userId levelName:failLevelName properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//任务信息日志发送接口测试
+- (void)testSendTaskInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"猪八戒";
+    NSString *beginTaskName = @"高老庄娶亲";
+    NSString *completeTaskName = @"情迷盘丝洞";
+    NSString *failTaskName = @"八戒大战流沙河";
+    
+    //开始任务信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendTaskBeginInfo:userId taskName:beginTaskName properties:NULL]);
+    
+    //完成任务信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendTaskComleteInfo:userId taskName:completeTaskName properties:NULL]);
+    
+    //失败任务信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendTaskFailInfo:userId taskName:failTaskName properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//物品信息日志发送接口测试
+- (void)testSendItemInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"孙悟空";
+    NSString *getItemName = @"金箍棒";
+    NSString *buyItemName = @"恢复魔力值药水";
+    NSString *consumeItmeName = @"长生不老丹药";
+    
+    //获得物品信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendGetItemInfo:userId itemName:getItemName properties:NULL]);
+    
+    //购买物品信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendBuyItemInfo:userId itemName:buyItemName properties:NULL]);
+    
+    //消耗物品信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendConsumeItemInfo:userId itemName:consumeItmeName properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//金币信息日志发送接口测试
+- (void)testSendCoinInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"沙和尚";
+    NSString *coinType = @"钻石";
+    long gain = 1000;
+    long use = 388;
+    long total = 3000;
+    NSString *gainReason = @"打败黑风怪";
+    NSString *useReason = @"被白骨精打伤";
+ 
+    //获得金币信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendGainCoinInfo:userId coinType:coinType gain:gain total:total reason:gainReason properties:NULL]);
+    
+    //消耗金币信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendConsumeCoinInfo:userId coinType:coinType use:use total:total reason:useReason properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+- (void)testSendPayInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"唐僧";
+    NSString *orderId = @"支付宝：12345667889";
+    NSString *iapId = @"付费模式";
+    NSString *amount = @"200";
+    NSString *currencyType = @"RMB";
+    NSString *paymentType = @"支付宝";
+    
+    //支付信息日志发送接口测试
+    XCTAssertTrue([LogAgent sendCurrencyPaymentInfo:userId orderId:orderId iapId:iapId amount:amount currencyType:currencyType paymentType:paymentType properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//自定义日志发送接口测试
+- (void)testSendCustomizedInfo
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"唐僧";
+    NSString *logType = @"partner_info";
+    NSMutableDictionary *properties = [[NSMutableDictionary alloc]initWithObjectsAndKeys:@"孙悟空",@"大师兄",@"猪八戒",@"二师兄",@"沙僧",@"三师兄",nil];
+    //自定义日志发送接口测试
+    XCTAssertTrue([LogAgent sendCustomizedInfo:userId logType:logType properties:properties]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+//漏斗日志发送接口测试
+- (void)testSendCustomizedFunnel
+{
+    // Open http stubs
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL (NSURLRequest *request) {
+        return [request.URL.absoluteString isEqualToString:@"http://api.lambdacloud.com/log/v2"]
+        && [request.HTTPMethod isEqualToString:@"PUT"];
+    } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+        return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"wsresponse.json", nil)
+                                                statusCode:200 headers:@{@"Content-Type":@"application/json"}];
+    }];
+    
+    // Send request
+    [LogSdkConfig SetLogSdkToken:@"testtoken"];
+    [LogAgent setDebugMode:true];
+    
+    //测试数据
+    NSString *userId = @"西游记";
+    NSString *funnelType = @"da_nao_tian_gong";
+    NSString *stepName = @"da_zhan_erlangshen";
+    NSString *stepStatus = @"begin";
+    NSString *decsription = @"大战二郎神";
+    //自定义日志发送接口测试
+    XCTAssertTrue([LogAgent sendCustomizedFunnel:userId funnelType:funnelType stepName:stepName stepStatus:stepStatus description:decsription properties:NULL]);
+    
+    // Close http stubs
+    [OHHTTPStubs removeAllStubs];
+}
+
+@end

--- a/ios/src/xcode/logsdkTests/LogUtilTest.m
+++ b/ios/src/xcode/logsdkTests/LogUtilTest.m
@@ -25,44 +25,47 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "LogSdkConfig.h"
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import <stdlib.h>
+#import "LogUtil.h"
 
-static NSString *logSdkToken = nil;
+@interface LogUtilTest : XCTestCase
 
-@implementation LogSdkConfig
+@end
 
-NSString *const kHttpUrl = @"http://api.lambdacloud.com/log/v2";
-NSString *const kLogTag = @"LambdacloudSDK";
-NSInteger const kHttpTimeoutSec = 60;
-NSInteger const kSpoutSleepTimeMS = 1000;
-NSInteger const kHttpStatusCodeSuccess = 200;
-NSInteger const kHttpStatusCodeTokenIllegal = 406;
-BOOL kDebug = false;
-NSInteger  kQueueSize = 100;
-//method name
-NSString *const kGetInternetConnectionStatus = @"getInternetConnectionStatus";
-NSString *const kGetDeviceName = @"getDeviceName";
-NSString *const kGetOperationInfo = @"getOperationInfo";
-NSString *const kGetSystemOs = @"getSystemOs";
+@implementation LogUtilTest
 
-+ (NSString *)LogSdkToken
+- (void)setUp
 {
-    @synchronized(self) {
-        return logSdkToken;
-    }
-}
-+ (NSInteger)kQueueSize{
-    return kQueueSize;
-}
-+ (BOOL)kDebug{
-    return kDebug;
+    [super setUp];
 }
 
-+ (void)SetLogSdkToken:(NSString *)token
+- (void)tearDown
 {
-    @synchronized(self) {
-        logSdkToken = token;
-    }
+    [super tearDown];
+}
+
+- (void)testGetBasicInfo
+{
+    XCTAssertNoThrow([LogUtil getBasicInfo:@"test" userId:@"testId"]);
+
+    NSLog(@"%@",[LogUtil getBasicInfo:@"test" userId:@"testId"]);
+}
+
+- (void)testGetTimeStamp
+{
+    XCTAssertNoThrow([LogUtil getTimeStamp]);
+
+    NSLog(@"时间为：%@",[LogUtil getTimeStamp]);
+}
+
+- (void)testDic2Str
+{
+    NSMutableDictionary *dic = [[NSMutableDictionary alloc]initWithObjectsAndKeys:@"value1",@"key1",@"value2",@"key2",@"value3",@"key3", nil];
+    XCTAssertNoThrow([LogUtil dic2str:dic]);
+
+    NSLog(@"DIC2STR: %@",[LogUtil dic2str:dic]);
 }
 
 @end


### PR DESCRIPTION
https://github.com/lambdacloud/lanyun/issues/1286
## LogAgent:
1. 设备信息日志发送接口(sendDeviceInfo)
2. 渠道信息日志发送接口(sendChannelInfo)
3. 登录登出日志发送接口(sendLoginInfo,sendLogoutInfo)
4. 用户标签日志发送接口(sendUserTag)
5. 关卡日志发送接口(sendLevelBeginInfdo,sendLevelComplete,sendLevelFailInfo)
6. 任务日志发送接口(sendTaskBeginInfo,sendTaskCompleteInfo,sendTaskFailInfo)
7. 物品信息日志发送接口(sendGetItemInfo,sendBuyItemInfo,sendConsumeItemInfo)
8. 金币信息日志发送接口(sendGainCoinInfo,sendConsumeCoinInfo)
9. 支付信息日志发送接口(sendCurrencyPaymentInfo)
10. 自定义日志发送接口(sendCustomizedInfo)
11. 漏斗日志发送接口(sendCustomizedFunnel)
12. debug方法转移到LogUtil中
13. 修改方法名setMaxQueueSize


## LogUtil:
1. 增加debug方法，方便调试程序
2. 添加getBasicInfo方法，在每条日志前加上固定字段
3. 添加getTimeStamp方法，获得当前日志发送时间
4. 添加dic2str方法，将NSMutableDictionary格式数据转化NSString类型

## LogSdkConfig:
1. 添加方法名字段，便于用于可配置化设备信息日志接口

## LogAgentTest:
1. 添加关于LogAgent中新添加方法的测试

## LogUtilTest:
1. 添加关于LogUtil中新添加方法的测试

## 其他:
其他修改均为将[LogAgent debug:true]修改为[LogUtil debug:true]
