### PR TITLE
IOS SDK 添加获取电量以及获取位置信息方法

### DIFF
--- a/ios/src/xcode/logsdk/DeviceInfo.h
+++ b/ios/src/xcode/logsdk/DeviceInfo.h
@@ -44,5 +44,7 @@ extern NSString *const  kIOS9;
 + (NSString *)getDeviceName;
 + (NSString *)getOperationInfo;
 + (NSString *)getSystemOS;
++ (NSString *)getBatteryPower;
++ (void)getLocation:(NSString *)userId;
 
 @end

--- a/ios/src/xcode/logsdk/DeviceInfo.mm
+++ b/ios/src/xcode/logsdk/DeviceInfo.mm
@@ -30,6 +30,7 @@
 #import <sys/utsname.h>
 #import "DeviceInfo.h"
 #import "Reachability.h"
+#import "Location.h"
 
 @implementation DeviceInfo
 
@@ -100,4 +101,17 @@ NSString *const kIOS9 = @"iOS9";
     }
 }
 
++ (NSString *)getBatteryPower
+{
+    [UIDevice currentDevice].batteryMonitoringEnabled = YES;
+    double deviceLevel = [UIDevice currentDevice].batteryLevel;
+    NSString *batteryPower = [NSString stringWithFormat:@"%g%%",deviceLevel * 100];
+    return batteryPower;
+}
+
++ (void)getLocation:(NSString *)userId
+{
+    Location *location = [Location sharedInstance];
+    [location startLocation:userId];
+}
 @end

--- a/ios/src/xcode/logsdk/Location.h
+++ b/ios/src/xcode/logsdk/Location.h
@@ -25,29 +25,17 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
 
-extern NSString *const kHttpUrl;
-extern NSString *const kLogTag;
-extern NSInteger const kHttpTimeoutSec;
-extern NSInteger const kSpoutSleepTimeMS;
-extern NSInteger const kHttpStatusCodeSuccess;
-extern NSInteger const kHttpStatusCodeTokenIllegal;
-extern BOOL kDebug;
-extern NSInteger  kQueueSize;
-//method name
-extern NSString *const kGetInternetConnectionStatus;
-extern NSString *const kGetDeviceName;
-extern NSString *const kGetOperationInfo;
-extern NSString *const kGetSystemOs;
-extern NSString *const kGetLocation;
-extern NSString *const kGetBatteryPower;
+@interface Location : NSObject <CLLocationManagerDelegate>
+@property (nonatomic, strong) CLLocationManager *locationManager;
+@property (nonatomic, strong) NSString *userID;
+@property (readonly, nonatomic) CLLocation *location;
 
-@interface LogSdkConfig : NSObject
-
-+ (NSString *)LogSdkToken;
-+ (NSInteger)kQueueSize;
-+ (BOOL)kDebug;
-+ (void)SetLogSdkToken:(NSString *)token;
++ (id)sharedInstance;
+- (id)init;
+- (void)startLocation:(NSString *)userId;
+- (void)stopLocation;
 
 @end

--- a/ios/src/xcode/logsdk/Location.mm
+++ b/ios/src/xcode/logsdk/Location.mm
@@ -1,0 +1,137 @@
+/**
+ *   Copyright (c) 2015, LambdaCloud
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "Location.h"
+#import "LogAgent.h"
+#import "LogUtil.h"
+#import "LogSdkConfig.h"
+
+@implementation Location
+
++(id)sharedInstance
+{
+    static Location *instance = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+    });
+    return instance;
+}
+
+- (id)init
+{    self = [super init];
+    if (self != nil) {
+        _locationManager = [[CLLocationManager alloc] init];
+        _locationManager.delegate = self;
+        _locationManager.desiredAccuracy = kCLLocationAccuracyBest;
+        _locationManager.distanceFilter = kCLDistanceFilterNone;
+        //8.0以上需要显式请求定位(在使用中请求定位)
+        if (([[[UIDevice currentDevice] systemVersion] doubleValue] >= 8.0) ? YES : NO) {
+            [_locationManager requestWhenInUseAuthorization];
+        }
+    }
+    return self;
+}
+
+- (void)startLocation:(NSString *)userId
+{
+    _userID = [[NSString alloc]init];
+    _userID = userId;
+    [_locationManager startUpdatingLocation];
+}
+
+- (void)stopLocation
+{
+    [_locationManager stopUpdatingLocation];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
+{
+    switch (status)
+    {
+        case kCLAuthorizationStatusNotDetermined:
+            if ([_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)])
+            {
+                [_locationManager requestWhenInUseAuthorization];
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+//6.0及其以上版本调用该回调
+-(void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations
+{
+    [self stopLocation];
+    _location = [locations lastObject];
+    CLGeocoder *geocoder = [[CLGeocoder alloc] init];
+    [geocoder reverseGeocodeLocation:_location
+                   completionHandler:^(NSArray *placemarks, NSError *error){
+                       for (CLPlacemark *place in placemarks) {
+                           NSString *locationInfo = [NSString stringWithFormat:@"ldp_latitude[%g],ldp_longitude[%g],ldp_place_name[%@]",_location.coordinate.latitude,_location.coordinate.longitude, place.name];
+                           [LogAgent sendLocationInfo:_userID locationInfo:locationInfo];
+                       }
+                   }];
+}
+
+//6.0以下调用该回调函数
+-(void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation {
+    [self stopLocation];
+    _location = newLocation;
+    CLGeocoder *geocoder = [[CLGeocoder alloc] init];
+    [geocoder reverseGeocodeLocation:_location
+                   completionHandler:^(NSArray *placemarks, NSError *error){
+                       for (CLPlacemark *place in placemarks) {
+                           NSString *locationInfo = [NSString stringWithFormat:@"ldp_latitude[%g],ldp_longitude[%g],ldp_place_name[%@]",_location.coordinate.latitude,_location.coordinate.longitude, place.name];
+                           [LogAgent sendLocationInfo:_userID locationInfo:locationInfo];
+                       }
+                   }];
+}
+
+-(void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
+{
+    NSMutableString *errorString = [[NSMutableString alloc] init];
+    if ([error domain] == kCLErrorDomain) {
+        switch ([error code]) {
+            case kCLErrorDenied:
+                [LogUtil debug:kLogTag message:@"User denied our request."];
+                break;
+            case kCLErrorLocationUnknown:
+                [LogUtil debug:kLogTag message:@"Can't get location info"];
+            default:
+                break;
+        }
+    } else {
+        [errorString appendFormat:@"Error domain: \"%@\"  Error code: %ld\n", [error domain], (long)[error code]];
+        [errorString appendFormat:@"Description: \"%@\"\n", [error localizedDescription]];
+        [LogUtil debug:kLogTag message:errorString];
+    }
+}
+
+@end

--- a/ios/src/xcode/logsdk/LogAgent.h
+++ b/ios/src/xcode/logsdk/LogAgent.h
@@ -34,6 +34,8 @@
 + (BOOL)addLog:(NSString *)message;
 + (BOOL)addLog:(NSString *)message tags:(NSArray *)tags;
 + (void)setDebugMode:(BOOL)debug;
+//地理位置信息日志发送接口
++ (BOOL)sendLocationInfo:(NSString *)userId locationInfo:(NSString *)locationInfo;
 //设备信息日志发送接口
 + (BOOL)sendDeviceInfo:(NSString *)userId properties:(NSMutableDictionary *)properties;
 + (BOOL)sendDeviceInfo:(NSString *)userId methods:(NSArray *)methods properties:(NSMutableDictionary *)properties;

--- a/ios/src/xcode/logsdk/LogAgent.mm
+++ b/ios/src/xcode/logsdk/LogAgent.mm
@@ -58,6 +58,14 @@
     return [[LogSpout sharedInstance] addRequest:message tags:tags];
 }
 
++ (BOOL)sendLocationInfo:(NSString *)userId locationInfo:(NSString *)locationInfo
+{
+     NSString *basicPart = [LogUtil getBasicInfo:@"ldp_device_info" userId:userId];
+    NSString *log = [[NSString alloc]initWithFormat:@"%@,%@",basicPart, locationInfo];
+    [LogUtil debug:kLogTag message:log];
+    return [LogAgent addLog:log];
+
+}
 + (BOOL)sendDeviceInfo:(NSString *)userId properties:(NSMutableDictionary *)properties
 {
     NSString *basicPart = [LogUtil getBasicInfo:@"ldp_device_info" userId:userId];
@@ -67,8 +75,9 @@
     NSString *internetConnectionStatus = [DeviceInfo getInternetConnectionStatus];
     NSString *operatorInfo = [DeviceInfo getOperationInfo];
     NSString *systemOs = [DeviceInfo getSystemOS];
+    NSString *batteryPower = [DeviceInfo getBatteryPower];
 
-    NSString *log = [[NSString alloc]initWithFormat:@"%@,ldp_device_name[%@],ldp_connection_status[%@],ldp_os_version[%@],ldp_operator[%@]%@",basicPart, deviceName, internetConnectionStatus, systemOs, operatorInfo, propPart];
+    NSString *log = [[NSString alloc]initWithFormat:@"%@,ldp_device_name[%@],ldp_connection_status[%@],ldp_os_version[%@],ldp_operator[%@],ldp_battery_power[%@]%@",basicPart, deviceName, internetConnectionStatus, systemOs, operatorInfo, batteryPower, propPart];
     [LogUtil debug:kLogTag message:log];
     return [LogAgent addLog:log];
 }
@@ -83,18 +92,22 @@
         return false;
     }
     for (int i=0;i<[methods count];i++) {
-        if ([[methods objectAtIndex:i] isEqualToString:kGetDeviceName]==YES) {
+        if ([[methods[i] lowercaseString] isEqualToString:[kGetDeviceName lowercaseString]]==YES) {
             NSString *deviceName = [[NSString alloc]initWithFormat:@",ldp_device_name[%@]",[DeviceInfo getDeviceName]];
             [log appendString:deviceName];
-        } else if ([methods[i] isEqualToString:kGetInternetConnectionStatus]==YES){
+        } else if ([[methods[i] lowercaseString] isEqualToString:[kGetInternetConnectionStatus lowercaseString]]==YES){
             NSString *internetConnectionStatus = [[NSString alloc]initWithFormat:@",ldp_connection_status[%@]",[DeviceInfo getInternetConnectionStatus]];
             [log appendString:internetConnectionStatus];
-        } else if ([methods[i] isEqualToString:kGetOperationInfo]==YES){
+        } else if ([[methods[i] lowercaseString] isEqualToString:[kGetOperationInfo lowercaseString]]==YES){
             NSString *operatorInfo = [[NSString alloc]initWithFormat:@",ldp_operator[%@]",[DeviceInfo getOperationInfo]];
             [log appendString:operatorInfo];
-        } else if ([methods[i] isEqualToString:kGetSystemOs]==YES){
+        } else if ([[methods[i] lowercaseString] isEqualToString:[kGetSystemOs lowercaseString]]==YES){
             NSString *systemOs = [[NSString alloc]initWithFormat:@",ldp_os_version[%@]",[DeviceInfo getSystemOS]];
             [log appendString:systemOs];
+        } else if ([[methods[i] lowercaseString] isEqualToString:[kGetBatteryPower lowercaseString]]==YES){
+            [DeviceInfo getBatteryPower];
+        } else if ([[methods[i] lowercaseString] isEqualToString:[kGetLocation lowercaseString]]==YES){
+            [DeviceInfo getLocation:userId];
         }
     }
     [log appendString:propPart];

--- a/ios/src/xcode/logsdk/LogSdkConfig.mm
+++ b/ios/src/xcode/logsdk/LogSdkConfig.mm
@@ -44,6 +44,8 @@ NSString *const kGetInternetConnectionStatus = @"getInternetConnectionStatus";
 NSString *const kGetDeviceName = @"getDeviceName";
 NSString *const kGetOperationInfo = @"getOperationInfo";
 NSString *const kGetSystemOs = @"getSystemOs";
+NSString *const kGetLocation = @"getLocation";
+NSString *const kGetBatteryPower = @"getBatteryPower";
 
 + (NSString *)LogSdkToken
 {

--- a/ios/src/xcode/logsdk/LogUtil.h
+++ b/ios/src/xcode/logsdk/LogUtil.h
@@ -27,8 +27,6 @@
 
 #import <Foundation/Foundation.h>
 
-
-
 @interface LogUtil : NSObject
 
 + (void)debug:(NSString *)tag message:(NSString *)message;

--- a/ios/src/xcode/logsdk/LogUtil.mm
+++ b/ios/src/xcode/logsdk/LogUtil.mm
@@ -25,11 +25,6 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <CoreTelephony/CTTelephonyNetworkInfo.h>
-#import <CoreTelephony/CTCarrier.h>
-#import <sys/utsname.h>
-#import "DeviceInfo.h"
-#import "Reachability.h"
 #import "LogSdkConfig.h"
 #import "LogUtil.h"
 


### PR DESCRIPTION
https://github.com/lambdacloud/lanyun/issues/1285
https://github.com/lambdacloud/lanyun/issues/1284
## DeviceInfo:
1.  添加获取电量方法(getBatteryPower)以及获取位置信息方法(getLocation)
    -  (NSString *)getBatteryPower;
    -  (void)getLocation:(NSString *)userId;

## Location:
1.  添加获取位置信息方法

## LogAgent:
1.  添加位置信息发送接口（位置信息获得后在后台自行发送）
    - (BOOL)sendLocationInfo:(NSString *)userId locationInfo:(NSString *)locationInfo;
2. 发送设备信息日志接口中添加电量字段
3. 发送特定设备信息日志接口进行方法字段优化，将传入字符串变为小写，并且添加获取位置信息以及电量的可配置

## LogSdkConfig:
1. 添加获取位置信息以及电量的字段

## LogUtil:
1. 删除不必要的引用

## DeviceInfoTest:
1. 添加相应方法的测试